### PR TITLE
Configure graphql path

### DIFF
--- a/src/graphiql.example/Controllers/GraphQlController.cs
+++ b/src/graphiql.example/Controllers/GraphQlController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace graphiql.example.Controllers
 {
-    [Route("graphql")]
+    [Route(Startup.GraphQLPath)]
     public class GraphQlController : Controller
     {
         [HttpPost]

--- a/src/graphiql.example/Startup.cs
+++ b/src/graphiql.example/Startup.cs
@@ -1,18 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace graphiql.example
 {
     public class Startup
     {
+        public const string GraphQLPath = "/api/graphql";
+        
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -29,7 +26,7 @@ namespace graphiql.example
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            app.UseGraphiQl();
+            app.UseGraphiQl(); // /api/graphql
             app.UseMvc();
         }
     }

--- a/src/graphiql/assets/index.html
+++ b/src/graphiql/assets/index.html
@@ -39,6 +39,7 @@
      -->
     <link rel="stylesheet" href="./graphiql.css" />
     <script src="./graphiql.js"></script>
+    <script src="./graphql-path.js"></script>
 
   </head>
   <body>
@@ -109,7 +110,7 @@
       function graphQLFetcher(graphQLParams) {
         // This example expects a GraphQL server at the path /graphql.
         // Change this to point wherever you host your GraphQL server.
-        return fetch('/graphql', {
+        return fetch(graphqlPath || '/graphql', {
           method: 'post',
           headers: {
             'Accept': 'application/json',

--- a/src/graphiql/graphiql.csproj
+++ b/src/graphiql/graphiql.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="./assets/**/*.*" />


### PR DESCRIPTION
Following #6 

This is not the best approach but easiest for clients to use.

Here is what happens if GraphQL url is not the default (as set in `index.html`):

- Create a temp dir `/tmp/graphiql-dotnet/graphql-path.js`
- Write `var graphqlPath='/api/graphql';`
- Serve it as file
- `index.html` loads the file and path is set